### PR TITLE
Enable SafeStart capabilities (for support of ManagedResourceAc…

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -11,3 +11,6 @@ metadata:
     meta.crossplane.io/readme: |
       `provider-proxmox-bpg` is the Crossplane infrastructure provider for Proxmox VE 
     friendly-name.meta.crossplane.io: Provider Proxmox BPG
+spec:
+  capabilities:
+  - SafeStart


### PR DESCRIPTION
Hello,

I was trying to use ManagedResourceActivationPolicies (https://docs.crossplane.io/latest/managed-resources/managed-resource-activation-policies/) with this provider, and I noticed that SafeStart is not enabled, although it should be support by the code.

Manuel